### PR TITLE
if case .none; add optional 'label:' param

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ let anotherString: String? = nil
 
 func testFunction() {
     guard let optionalString = optionalString.safeguard(),
-          let anotherString = anotherString.safeguard() else {
+          let anotherString = anotherString.safeguard("anotherString") else {
         return
     }
 
     print("This is \(optionalString) and \(anotherString) in a sentence.")
 }
 
-testFunction() // Logs filename, caller/function name, line # for anotherString, and type (String here)
+testFunction() // Logs label (passed as "anotherString" here), filename, caller/function name, line # for anotherString, and type (String here)
 ```
 By separating cascading `let` statements onto separate lines we can log the line number to the specific failed assignment/unwrap in the guard statement. Without this, it can be difficult to tell which unwrap may have failed.
 

--- a/Safeguard.podspec
+++ b/Safeguard.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name         = "Safeguard"
-  s.version      = "2.0.1"
+  s.version      = "2.1"
   s.summary      = "A lightweight, flexible tool to help identify and log issues lost in Swift's guard statements."
 
   s.description  = <<-DESC

--- a/Safeguard/Core/Safeguard.swift
+++ b/Safeguard/Core/Safeguard.swift
@@ -22,7 +22,13 @@ public class Safeguard {
 
     var customLoggingParams: [String: Any]?
 
-    // Note: - Passing nil to a parameter will not modify setting
+    /// Safeguard's initial configuration function -- required for proper functionality
+    /// Note: - Passing nil to a parameter will not modify current setting
+    ///
+    /// - Parameters:
+    ///   - logger: Your Logger which conforms to the SafeLoggable protocol
+    ///   - customLoggingParams: Any custom logging params to be included with every log
+    ///   - nilHandler: Custom handling in the the case of an Optional.none
     public static func configure(logger: SafeLoggable? = nil, customLoggingParams: [String: Any]? = nil, nilHandler: ((Bool) -> Void)? = nil) {
         if let logger = logger {
             instance.logger = logger

--- a/Safeguard/Extensions/Dictionary+Safeguard.swift
+++ b/Safeguard/Extensions/Dictionary+Safeguard.swift
@@ -10,7 +10,5 @@ import Foundation
 
 func += <K, V> (left: inout [K: V], right: [K: V]?) {
     guard let right = right else { return }
-    right.forEach { key, value in
-        left.updateValue(value, forKey: key)
-    }
+    right.forEach { left.updateValue($1, forKey: $0) }
 }

--- a/Safeguard/Extensions/Optional+Safeguard.swift
+++ b/Safeguard/Extensions/Optional+Safeguard.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension Optional {
     public func safeguard(file: String = #file, caller: String = #function, line: Int = #line) -> Optional {
-        if self == nil {
+        if case .none = self {
             let type: Wrapped.Type = Wrapped.self
             let fileName: String = URL(fileURLWithPath: file).lastPathComponent
             let message: String = "Guard failed with type: \(type)"

--- a/Safeguard/Extensions/Optional+Safeguard.swift
+++ b/Safeguard/Extensions/Optional+Safeguard.swift
@@ -9,11 +9,25 @@
 import Foundation
 
 extension Optional {
-    public func safeguard(file: String = #file, caller: String = #function, line: Int = #line) -> Optional {
+    /// safeguard() passes information to your application's logger if an unexpected nil value is encountered
+    ///
+    /// - Parameters:
+    ///   - label: An unrequired label to provide custom messaging or variable name, if desired
+    ///   - file: The file where the nil variable is located
+    ///   - caller: The location/calling function where the nil variable is located
+    ///   - line: The line #  where the nil variable is located
+    /// - Returns: The unaltered Optional value
+    public func safeguard(_ label: String? = nil, file: String = #file, caller: String = #function, line: Int = #line) -> Optional {
         if case .none = self {
             let type: Wrapped.Type = Wrapped.self
             let fileName: String = URL(fileURLWithPath: file).lastPathComponent
-            let message: String = "Guard failed with type: \(type)"
+            let defaultMessage: String = "Unexpected nil value for \(type) type"
+
+            var message: String = defaultMessage
+
+            if let label = label {
+                message = "\(label) | \(defaultMessage)"
+            }
 
             var params: [String: Any] = [
                 "failed_unwrap_type": type,

--- a/Safeguard/Extensions/Optional+Safeguard.swift
+++ b/Safeguard/Extensions/Optional+Safeguard.swift
@@ -45,7 +45,7 @@ extension Optional {
             var isDebug = false
 
             #if DEBUG
-                safeguardLogger?.debug(message: "\(message) and params: \(params)")
+                safeguardLogger?.debug(message: "\(message) with params: \(params)")
                 isDebug = true
             #else
                 safeguardLogger?.warn(message: message, properties: params)

--- a/Safeguard/Info.plist
+++ b/Safeguard/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.1</string>
+	<string>2.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/SafeguardTests/SafeguardTests.swift
+++ b/SafeguardTests/SafeguardTests.swift
@@ -16,6 +16,10 @@ class SafeguardTests: XCTestCase {
 
     let testLogger = TestLogger()
 
+    var expectedLabel: String {
+        return "emptyOptional | "
+    }
+
     override func setUp() {
         super.setUp()
         emptyOptional = nil
@@ -41,7 +45,7 @@ class SafeguardTests: XCTestCase {
     func testNilOptional() {
         if let _ = emptyOptional.safeguard() {} // Continue
 
-        XCTAssertEqual(testLogger.testString, "Guard failed with type: String and params: [\"failed_unwrap_type\": Swift.String, \"file\": \"SafeguardTests.swift\", \"safe\": \"guard\", \"called_from\": \"testNilOptional()\", \"line\": 42]")
+        XCTAssertEqual(testLogger.testString, expectedNonLabelString(functionName: "testNilOptional()",lineNumber: "46"))
         XCTAssertEqual(nilHandledString, "notNilSafeguard")
     }
 
@@ -50,5 +54,16 @@ class SafeguardTests: XCTestCase {
 
         XCTAssertNil(testLogger.testString)
         XCTAssertNil(nilHandledString)
+    }
+
+    func testCustomLabel() {
+        if let _ = emptyOptional.safeguard("emptyOptional") {} // Continue
+
+        XCTAssertEqual(testLogger.testString, expectedLabel + expectedNonLabelString(functionName: "testCustomLabel()", lineNumber: "60"))
+        XCTAssertEqual(nilHandledString, "notNilSafeguard")
+    }
+
+    func expectedNonLabelString(functionName: String, lineNumber: String) -> String {
+        return "Unexpected nil value for String type with params: [\"failed_unwrap_type\": Swift.String, \"file\": \"SafeguardTests.swift\", \"safe\": \"guard\", \"called_from\": \"\(functionName)\", \"line\": \(lineNumber)]"
     }
 }


### PR DESCRIPTION
- Add optional label param for extra/more custom messaging
- Change from equality check to `if case .none`